### PR TITLE
Add `orElse`

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -3,7 +3,7 @@ module Result.Extra exposing (..)
 {-| Convenience functions for working with Result
 
 # Common Helpers
-@docs isOk, isErr, extract, mapBoth, combine, orThen
+@docs isOk, isErr, extract, mapBoth, combine, orElse
 
 -}
 
@@ -70,8 +70,8 @@ combine =
 produce another one. Useful for chaining together a series of
 `Result`-producing functions when you want the first `Ok`.
 -}
-orThen : (a -> Result x b) -> a -> Result x b -> Result x b
-orThen func input res =
+orElse : (a -> Result x b) -> a -> Result x b -> Result x b
+orElse func input res =
     case res of
         Ok _ -> res
         _ -> func input

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -3,7 +3,7 @@ module Result.Extra exposing (..)
 {-| Convenience functions for working with Result
 
 # Common Helpers
-@docs isOk, isErr, extract, mapBoth, combine
+@docs isOk, isErr, extract, mapBoth, combine, orThen
 
 -}
 
@@ -64,3 +64,14 @@ mapBoth errFunc okFunc result =
 combine : List (Result x a) -> Result x (List a)
 combine =
     List.foldr (Result.map2 (::)) (Ok [])
+
+
+{-| If a `Result` is `Ok`, return it, otherwise call a function to
+produce another one. Useful for chaining together a series of
+`Result`-producing functions when you want the first `Ok`.
+-}
+orThen : (a -> Result x b) -> a -> Result x b -> Result x b
+orThen func input res =
+    case res of
+        Ok _ -> res
+        _ -> func input


### PR DESCRIPTION
Add an `orElse` function for chaining together a series of `Result`-producing functions when you want the first `Ok`.

See "orThen for Result / Maybe" on elm-discuss:
https://groups.google.com/forum/?fromgroups#!topic/elm-discuss/Qj5WQ47TS3c