### PR TITLE
merge : Result a a -> a -- Remove result when mapping makes it redundant

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -11,6 +11,7 @@ module Result.Extra
         , orLazy
         , orElseLazy
         , orElse
+        , merge
         )
 
 {-| Convenience functions for working with `Result`.
@@ -181,3 +182,28 @@ orElse ra rb =
 
         Ok _ ->
             rb
+
+{-| Eliminate Result when error and success have been mapped to the same
+type, such as a message type.
+
+    merge (Ok 4)   == 4
+    merge (Err -1) == -1
+
+More pragmatically:
+
+    type Msg
+        = UserTypedInt Int
+        | UserInputError String
+
+    msgFromInput : String -> Msg
+    msgFromInput =
+        String.toInt
+        >> Result.mapError UserInputError
+        >> Result.map UserTypedInt
+        >> Result.Extra.merge
+-}
+merge : Result a a -> a
+merge r =
+    case r of
+        Ok rr -> rr
+        Err rr -> rr

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -17,7 +17,7 @@ module Result.Extra
 {-| Convenience functions for working with `Result`.
 
 # Common Helpers
-@docs isOk, isErr, extract, unwrap, unpack, mapBoth, combine
+@docs isOk, isErr, extract, unwrap, unpack, mapBoth, combine, merge
 
 # Alternatives
 @docs or, orLazy, orElseLazy, orElse


### PR DESCRIPTION
Does this belong in Result.Extra?

I use merge often in pipelines where a result is mapped to a success message or an error message, especially with Http in 0.18 and things like this:

    type Msg                                                                                                                         
        = UserTypedInt Int                                                                                                           
        | UserInputError String                                                                                                      
                                                                                                                                     
    msgFromInput : String -> Msg                                                                                                     
    msgFromInput =                                                                                                                   
        String.toInt                                                                                                                 
        >> Result.mapError UserInputError                                                                                            
        >> Result.map UserTypedInt                                                                                                   
        >> Result.Extra.merge                                                                                                        
