### PR TITLE
Add `toTask` function

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -2,6 +2,7 @@ module Tests exposing (..)
 
 import Test exposing (..)
 import Expect
+import Task
 import Result.Extra exposing (..)
 
 
@@ -24,5 +25,11 @@ all =
             , test "andMap Ok Ok" <|
                 \() ->
                     Expect.equal (Ok ((+) 1) |> andMap (Ok 2)) (Ok 3)
+            , test "toTask Ok" <|
+                \() ->
+                    Expect.equal (toTask (Ok 4)) (Task.succeed 4)
+            , test "toTask Err" <|
+                \() ->
+                    Expect.equal (toTask (Err "Oh")) (Task.fail "Oh")
             ]
         ]


### PR DESCRIPTION
Add a helper that can convert a `Result` to a `Task`. This may or may not be worth adding to the community lib, but I've found it useful enough that I thought I would share.