### PR TITLE
Add `forceExtract` / Rust-style unwrap

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -71,8 +71,13 @@ extract f x =
 {-| Extract a value `a` from a `Result _ a` or crash
 -}
 forceExtract : Result e a -> a
-forceExtract =
-    extract (Debug.crash "forceExtract on (Err e)")
+forceExtract x =
+    case x of
+        Ok a ->
+            a
+
+        Err _ ->
+            Debug.crash "force unwrapping failed"
 
 
 {-| Convert a `Result e a` to a `b` by applying a function if

--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -3,6 +3,7 @@ module Result.Extra
         ( isOk
         , isErr
         , extract
+        , forceExtract
         , unwrap
         , unpack
         , mapBoth
@@ -19,7 +20,7 @@ module Result.Extra
 {-| Convenience functions for working with `Result`.
 
 # Common Helpers
-@docs isOk, isErr, extract, unwrap, unpack, mapBoth, combine, merge
+@docs isOk, isErr, extract, forceExtract, unwrap, unpack, mapBoth, combine, merge
 
 # Applying
 @docs singleton, andMap
@@ -65,6 +66,13 @@ extract f x =
 
         Err e ->
             f e
+
+
+{-| Extract a value `a` from a `Result _ a` or crash
+-}
+forceExtract : Result e a -> a
+forceExtract =
+    extract (Debug.crash "forceExtract on (Err e)")
 
 
 {-| Convert a `Result e a` to a `b` by applying a function if

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -24,5 +24,8 @@ all =
             , test "andMap Ok Ok" <|
                 \() ->
                     Expect.equal (Ok ((+) 1) |> andMap (Ok 2)) (Ok 3)
+            , test "forceExtract Ok" <|
+                \() ->
+                    Expect.equal (2) (forceExtract <| Ok 2)
             ]
         ]


### PR DESCRIPTION
The library could benefit from a function that works like Rust's `unwrap`:

```elm
-- Crashes if `Date.fromString` returns an `Err`
someDate = forceUnwrap (Date.fromString "2017-05-26")
```

I believe this would close a few gaps, e.g. when dealing with the construction of constants via string parsing. Supplying a default value in case of failure is impractical here because the difficulty of constructing such a value may be the reason for defining the constant in the first place. It is usually desirable to have the program crash if these things fail.
