### PR TITLE
Add traversals

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,8 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/core": "1.0.0 <= v < 2.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm-community/basics-extra": "4.0.0 <= v < 5.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"


### PR DESCRIPTION
This PR adds a bunch of convenience functions know as `sequence`, `traverse` and `bitraverse` in the Haskell/PureScript/Idris/Agda community. However, we use friendlier names that match current once in Results.Extra and Tuple.

These functions make it easy to map erroneous computations over a list, and combine all these results into one. Also, it adds `join`, which can be seen as a combine on stacked results.

- next to `combine` (sequence), add `combineMap` (traverse) on lists
- do the same for tuples: `combineFirst`, `combineSecond` (sequence), 
`combineBoth` (bisequence), `combineMapFirst`, `combineMapSecond` (traverse), 
`combineMapBoth` (bitraverse)
- add `join` to combine stacked results

What do you think of these changes?