### PR TITLE
Add partition function, analogous to List.partition

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -14,12 +14,13 @@ module Result.Extra
         , orElseLazy
         , orElse
         , merge
+        , partition
         )
 
 {-| Convenience functions for working with `Result`.
 
 # Common Helpers
-@docs isOk, isErr, extract, unwrap, unpack, mapBoth, combine, merge
+@docs isOk, isErr, extract, unwrap, unpack, mapBoth, combine, merge, partition
 
 # Applying
 @docs singleton, andMap
@@ -246,3 +247,21 @@ merge r =
 
         Err rr ->
             rr
+
+{-| Partition a list of Results into two lists of values (successes
+and failures), much as List.partition takes a predicate and splits
+a list based on whether the predicate indicates success or failure.
+
+    partition (Ok 4, Err "no", Err "hi")         == ([4], ["no", "hi"])
+    partition (Err 7.1, Ok 'k', Err 9.0, Ok 'p') == (['k', 'p'], [7.1, 9.0])
+-}
+partition : List (Result e a) -> (List a, List e)
+partition rs =
+    List.foldr (\r (succ,err) ->
+        case r of
+            Ok v ->
+                (v::succ, err)
+
+            Err v ->
+                (succ, v::err)
+    ) ([],[]) rs

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -24,5 +24,17 @@ all =
             , test "andMap Ok Ok" <|
                 \_ ->
                     Expect.equal (Ok ((+) 1) |> andMap (Ok 2)) (Ok 3)
+            , test "partition []" <|
+                \_ ->
+                    Expect.equal (partition []) ([], [])
+            , test "partition [Ok]" <|
+                \_ ->
+                    Expect.equal (partition [Ok 99]) ([99], [])
+            , test "partition [Err]" <|
+                \_ ->
+                    Expect.equal (partition [Err 99]) ([], [99])
+            , test "partition [Ok, Err, Ok]" <|
+                \_ ->
+                    Expect.equal (partition [Ok 99, Err "Nope", Ok -5]) ([99, -5], ["Nope"])
             ]
         ]


### PR DESCRIPTION
This is useful when the "failure" path must still be processed, perhaps in order to retry certain items.  In that case, generating a list of Results is worthwhile: the "success" cases can be handled in one way and the "failure" cases can be handled in another way.  This function separates those cases for separate processing.