### PR TITLE
Add a `transpose` function

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -1,5 +1,5 @@
 module Result.Extra exposing
-    ( isOk, isErr, extract, unwrap, unpack, error, mapBoth, merge, join, partition, filter
+    ( isOk, isErr, extract, unwrap, unpack, error, mapBoth, merge, join, partition, filter, transpose
     , combine, combineMap, combineFirst, combineSecond, combineBoth, combineMapFirst, combineMapSecond, combineMapBoth
     , singleton, andMap
     , or, orLazy, orElseLazy, orElse
@@ -11,7 +11,7 @@ module Result.Extra exposing
 
 # Common Helpers
 
-@docs isOk, isErr, extract, unwrap, unpack, error, mapBoth, merge, join, partition, filter
+@docs isOk, isErr, extract, unwrap, unpack, error, mapBoth, merge, join, partition, filter, transpose
 
 
 # Combining
@@ -443,6 +443,29 @@ filter err predicate result =
 
         Err _ ->
             result
+
+
+{-| Pull out a Result from a Maybe.
+
+    transpose Nothing =
+        Ok Nothing
+    transpose (Just (Ok "value")) =
+        Ok (Just "value")
+    transpose (Just (Err "error")) =
+        Err "error"
+
+-}
+transpose : Maybe (Result e a) -> Result e (Maybe a)
+transpose maybeOfResult =
+    case maybeOfResult of
+        Nothing ->
+            Ok Nothing
+
+        Just (Err err) ->
+            Err err
+
+        Just (Ok value) ->
+            Ok (Just value)
 
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -28,6 +28,7 @@ import Result.Extra
         , partition
         , singleton
         , toTask
+        , transpose
         , unwrap
         )
 import Task
@@ -103,6 +104,7 @@ commonHelperTests =
                 Expect.equal (join <| Err 42) (Err 42)
         , partitionTests
         , filterTests
+        , transposeTests
         ]
 
 
@@ -142,6 +144,27 @@ filterTests =
                 Ok 2
                     |> filter "is not 1" ((==) 1)
                     |> Expect.equal (Err "is not 1")
+        ]
+
+
+transposeTests : Test
+transposeTests =
+    describe "transpose"
+        [ test "Nothing" <|
+            \_ ->
+                Nothing
+                    |> transpose
+                    |> Expect.equal (Ok Nothing)
+        , test "Just Ok" <|
+            \_ ->
+                Just (Ok 1)
+                    |> transpose
+                    |> Expect.equal (Ok (Just 1))
+        , test "Just Err" <|
+            \() ->
+                Just (Err 2)
+                    |> transpose
+                    |> Expect.equal (Err 2)
         ]
 
 


### PR DESCRIPTION
Add a `transpose` function that pulls out a `Result` from a `Maybe`.

```elm
transpose : Maybe (Result e a) -> Result e (Maybe a)
```

Comparison to other languages:
- [Rust](https://doc.rust-lang.org/std/option/enum.Option.html#method.transpose) uses the same name for this function.
- In [Haskell](https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Traversable.html#v:sequence) and [PureScript](https://pursuit.purescript.org/packages/purescript-foldable-traversable/5.0.1/docs/Data.Traversable#v:sequence) `sequence` from `Traversable` does approximately the same, but in a more generic fashion.

